### PR TITLE
option 'wsoptions' added to pass through options to WebSocket

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var WSRECONNECT = function(url, options) {
 	}
 	this.url 					= url && url.indexOf("ws") == -1 ? "ws://"+url : url;
 	this.options 				= options || {};
+	this.wsoptions				= this.options.wsoptions || {};
 	this.socket 				= null;
 	this.isConnected 			= false;
 	this.reconnectTimeoutId 	= 0;
@@ -19,7 +20,7 @@ var WSRECONNECT = function(url, options) {
     this.start = function(){
         this.shouldAttemptReconnect = !!this.reconnectInterval;
         this.isConnected 		 	= false;
-        this.socket 			 	= new WebSocket(this.url);
+        this.socket 			 	= new WebSocket(this.url, this.wsoptions);
         this.socket.onmessage 	 	= this.onMessage.bind(this);
         this.socket.onopen 		 	= this.onOpen.bind(this);
         this.socket.onerror		 	= this.onError.bind(this);


### PR DESCRIPTION
var WSCLINET = require('ws-reconnect');
var wsclient = new WSCLIENT("localhost:1010",{
	wsoptions: { 'headers': { 
		'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.79 Mobile Safari/537.36'
		}
	}
});

Unable to connect with ws-reconnect I found that the server I was to connect to needed at least the 'User-Agent' header passed.